### PR TITLE
add more metrics ()

### DIFF
--- a/cli/run_benchmark_suite.py
+++ b/cli/run_benchmark_suite.py
@@ -95,7 +95,7 @@ def run_benchmark_suite_cli(config_path: str, *, fast_mode: bool = False) -> Non
         print(
             f"   {datasette_url}/stopwatch/-/query?sql=select+*+from+"
             f"{suite_id.replace('-', '_')}_averaged+where+rate_type+%21%3D+"
-            '"throughput"',
+            "'throughput'",
         )
     except Exception:  # noqa: BLE001
         print("- Deploy the Datasette UI with:")

--- a/stopwatch/run_benchmark_suite.py
+++ b/stopwatch/run_benchmark_suite.py
@@ -384,6 +384,7 @@ async def run_benchmark_suite(
     create_all()
 
     # STEP 0: Validate benchmarks
+    print("step 0/4: validating benchmarks...")
     for benchmark in benchmarks:
         for key in [
             "llm_server_type",
@@ -414,6 +415,7 @@ async def run_benchmark_suite(
         }
 
     # STEP 1: Run synchronous and throughput benchmarks
+    print("step 1/4: run synchronous and throughput benchmarks...")
     # TODO(jack): If repeat_index is increased, all of the constant rate benchmarks need
     # to be re-run with the new synchronous and throughput rates in mind
     await run_benchmarks_in_parallel(
@@ -439,6 +441,7 @@ async def run_benchmark_suite(
     )
 
     # STEP 2: Run benchmarks at constant rates
+    print("step 2/4: run benchmark at constant rates...")
     benchmarks_to_run = []
     skipped_benchmark_indices = set()
 
@@ -531,6 +534,7 @@ async def run_benchmark_suite(
     await run_benchmarks_in_parallel(benchmarks_to_run)
 
     # STEP 2.5: Delete existing benchmark results
+    print("step 2.5/4: delete existing benchmark results...")
     for cls in [SuiteBenchmark, SuiteAveragedBenchmark]:
         cls.__table__.drop(engine, checkfirst=True)
         cls.__table__.create(engine)
@@ -538,6 +542,7 @@ async def run_benchmark_suite(
     # STEP 3: Average the results together. Start by finding the parameters that vary
     # between benchmarks in order to get descriptive group IDs for each averaged
     # benchmark.
+    print("step 3/4: averaging benchmark results...")
     parameters = {}
 
     for benchmark in benchmarks:
@@ -658,4 +663,5 @@ async def run_benchmark_suite(
     db_volume.commit()
 
     # STEP 4: Export results in frontend format
+    print("step 4/4: export results to frontend format...")
     export_results.local(SuiteAveragedBenchmark)


### PR DESCRIPTION
Add support for:
- generated tokens
- gpu_seconds_per_query
- gpu_seconds_per_1M_tokens

Riders:
- print statements for o11y
- make datasette_url link clickable (not sure why it was done this way, maybe I'm breaking your version?)

Example stuff we can create:
![Figure_1](https://github.com/user-attachments/assets/f9b6b79e-0cef-4f14-8ecb-65ded853bff0)
(code not included)