### PR TITLE
update transforms

### DIFF
--- a/src/web/etl.py
+++ b/src/web/etl.py
@@ -31,6 +31,7 @@ etl_image = (
         "SQLAlchemy",
     )
     .add_local_file("src/stopwatch/resources.py", "/root/stopwatch/resources.py")
+    .add_local_dir("src/stopwatch/db", "/root/stopwatch/db")
 )
 
 with etl_image.imports():
@@ -137,6 +138,7 @@ def read_jsonl(file_path: str | Path) -> list[dict]:
 @web_app.function(
     image=etl_image,
     volumes={DB_PATH: db_volume, RESULTS_PATH: results_volume},
+    max_inputs=1,
 )
 @modal.fastapi_endpoint()
 def export_results(suite_ids: str, *, verbose: bool = False):  # noqa: ANN201

--- a/src/web/transforms.py
+++ b/src/web/transforms.py
@@ -32,6 +32,7 @@ SIZE_PATTERN = re.compile(
 # we hard-code a value.
 REPO_TO_SIZE = {
     "cognitivecomputations/DeepSeek-V3-0324-AWQ": "671B-A37B",
+    "deepseek-ai/DeepSeek-V3-0324": "671B-A37B",
     "zed-industries/zeta": "7B",
 }
 
@@ -271,8 +272,11 @@ def get_model_quant(row) -> str | None:  # noqa: ANN001, PLR0911
         if matches:
             return f"int{matches[-1]}"  # digit
 
-    if "awq" in model_name and "deepseek" in model_name:
-        return "int4"
+    if "deepseek" in model_name:
+        if "awq" in model_name:
+            return "int4"
+        else:
+            return "fp8"
 
     if dtype:
         return DTYPE_TO_QUANT.get(dtype, dtype)


### PR DESCRIPTION
1. Adds new location of the `stopwatch.db` module to the `etl_image`. The `etl` module depended on that import. 
2. Adds model name and quant inference for DeepSeek in fp8.
3. Adds a hash ID for each experiment/workload to the `df` during `transforms` processing to allow for simpler groupbys/filtering/sorting in the future.
4. Adds a jank lil filter to remove the H200 DeepSeek results in favor of the B200 results. Would rather not throw them out entirely but want to punt on figuring out the frontend handling of different GPU types. Could have done this by editing the configs, I think -- removing the H200 results from `full-suite` and putting them in a separate file, then running that file and the new `full-suite`? But wasn't 100% sure and didn't want to nuke the data.

These changes enabled an update to the results in the LLM Engineer's Almanac frontend:
<img width="1902" height="1470" alt="Screenshot 2025-07-28 at 7 06 25 PM" src="https://github.com/user-attachments/assets/ab7e24e5-792e-41ac-ba5a-739e78a29ae2" />
